### PR TITLE
Flet stability: clamp Tabs.selected_index in SelfTest to visible tabs…

### DIFF
--- a/src/ui/setting/self_test.py
+++ b/src/ui/setting/self_test.py
@@ -52,13 +52,16 @@ class SelfTest(ft.Tabs):
                 self.tab_hmi_server = ft.Tab(text="HMI Server", content=self.hmi_server_log, visible=not gdata.configCommon.is_master)
                 self.tab_gps = ft.Tab(text="GPS", content=self.gps_log, visible=gdata.configCommon.enable_gps)
                 self.tab_plc = ft.Tab(text="PLC", content=self.plc_log, visible=gdata.configIO.plc_enabled)
-                self.tabs = [
-                    self.tab_sps,
-                    self.tab_sps2,
-                    self.tab_hmi_server,
-                    self.tab_gps,
-                    self.tab_plc
-                ]
+                # Build list and clamp selected_index to visible tabs
+                tabs_all = [self.tab_sps, self.tab_sps2, self.tab_hmi_server, self.tab_gps, self.tab_plc]
+                visible_tabs = [t for t in tabs_all if t.visible]
+                self.tabs = visible_tabs if visible_tabs else tabs_all
+                try:
+                    if hasattr(self, "selected_index"):
+                        max_idx = max(0, len(self.tabs) - 1)
+                        self.selected_index = min(getattr(self, "selected_index", 0) or 0, max_idx)
+                except Exception:
+                    logging.exception('exception occured clamping SelfTest.selected_index')
         except:
             logging.exception('exception occured at SelfTest.build')
 

--- a/src/ui/setting/test_mode/test_mode_instant.py
+++ b/src/ui/setting/test_mode/test_mode_instant.py
@@ -56,18 +56,18 @@ class TestModeInstant(ft.ResponsiveRow):
 
                     self.controls = [
                         CustomCard(
-                            f'sps {self.page.session.get('lang.setting.test_mode.instant_mock_data')}',
+                            f"sps {self.page.session.get('lang.setting.test_mode.instant_mock_data')}",
                             self.sps_instant_data_card
                         ),
                         CustomCard(
-                            f'sps2 {self.page.session.get('lang.setting.test_mode.instant_mock_data')}',
+                            f"sps2 {self.page.session.get('lang.setting.test_mode.instant_mock_data')}",
                             self.sps2_instant_data_card
                         )
                     ]
                     return
 
                 self.controls = [
-                    CustomCard(f'sps {self.page.session.get('lang.setting.test_mode.instant_mock_data')}', self.sps_instant_data_card)
+                    CustomCard(f"sps {self.page.session.get('lang.setting.test_mode.instant_mock_data')}", self.sps_instant_data_card)
                 ]
         except:
             logging.exception('exception occured at TestModeInstant.build')


### PR DESCRIPTION
…; fix f-string quoting in TestModeInstant labels