### PR TITLE
Fix flet web app logging error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ websockets==15.0.1
 msgpack==1.1.0
 pynmea2==1.19.0
 pyserial==3.5
+pystray==0.19.5
+Pillow==10.4.0

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -3,15 +3,17 @@ import sys
 from peewee import SqliteDatabase, DateTimeField, Model, IntegerField
 from datetime import datetime
 
-# Get the absolute path to the project root directory
-# PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
- # 如果是打包环境（PyInstaller临时目录）
+# 选择可写的数据库目录
 if getattr(sys, 'frozen', False):
-    PROJECT_ROOT = sys._MEIPASS  # PyInstaller解压目录
+    # 打包环境：使用可写的可执行文件所在目录下的 data 子目录
+    exe_dir = os.path.dirname(sys.executable)
+    data_dir = os.path.join(exe_dir, 'data')
+    os.makedirs(data_dir, exist_ok=True)
+    DB_PATH = os.path.join(data_dir, '988bbc4fc383')
 else:
-    PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))  # 本地开发目录
-    
-DB_PATH = os.path.join(PROJECT_ROOT, '988bbc4fc383')
+    # 本地开发：使用当前文件所在目录
+    project_root = os.path.dirname(os.path.abspath(__file__))
+    DB_PATH = os.path.join(project_root, '988bbc4fc383')
 
 db = SqliteDatabase(DB_PATH)
 

--- a/src/main.py
+++ b/src/main.py
@@ -180,6 +180,16 @@ async def main(page: ft.Page):
 if __name__ == "__main__":
     try:
         check_single_instance()
-        ft.app(target=main, view=ft.AppView.WEB_BROWSER, host='localhost', port=80)
+        # Start system tray for quick access and exit control
+        try:
+            from utils.systray import start_tray
+            # Use non-admin port for web
+            port = 3000
+            url = f"http://127.0.0.1:{port}"
+            start_tray("Shaft Power Meter", url, icon_rel_path='assets/icon.png')
+        except Exception:
+            logging.warning("failed to start tray icon", exc_info=True)
+
+        ft.app(target=main, view=ft.AppView.WEB_BROWSER, host='127.0.0.1', port=3000)
     except Exception:
         logging.exception("fatal")

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,13 @@ import sys
 import logging
 import ui_safety
 import flet as ft
+import os
+# Ensure stderr/stdout exist in no-console environments (e.g., packaged GUI)
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w")
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w")
+
 from ui.common.fullscreen_alert import FullscreenAlert
 from ui.common.keyboard import keyboard
 from ui.header.index import Header

--- a/src/ui/header/logo.py
+++ b/src/ui/header/logo.py
@@ -11,12 +11,11 @@ class HeaderLogo(ft.Container):
 
     def get_src(self):
         try:
-            # Get absolute path to ensure reliability
-            base_dir = Path(__file__).parent.parent.parent
+            # Always return web-served assets path (works in dev and packaged web)
             if self.page is not None and self.page.theme_mode == ft.ThemeMode.LIGHT:
-                return os.path.join(base_dir, "assets", "logo_dark.png")
+                return "assets/logo_dark.png"
             else:
-                return os.path.join(base_dir, "assets", "logo_light.png")
+                return "assets/logo_light.png"
         except:
             logging.exception('exception occured at HeaderLogo.get_src')
 

--- a/src/utils/systray.py
+++ b/src/utils/systray.py
@@ -1,0 +1,101 @@
+import threading
+import os
+import sys
+import logging
+import webbrowser
+from typing import Optional
+
+
+_icon = None
+_icon_thread: Optional[threading.Thread] = None
+_running = False
+
+
+def _get_icon_image(icon_path: str):
+    try:
+        from PIL import Image
+        return Image.open(icon_path)
+    except Exception:
+        logging.exception("failed to load tray icon image: %s", icon_path)
+        return None
+
+
+def _resolve_asset_path(relative_path: str) -> str:
+    """
+    Resolve an asset path for both dev and frozen (PyInstaller) environments.
+    """
+    if getattr(sys, 'frozen', False):
+        # In packaged exe, assets folder is next to the executable
+        base_dir = os.path.dirname(sys.executable)
+    else:
+        # In dev, assets folder is under project src
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base_dir, relative_path)
+
+
+def start_tray(app_name: str, url: str, icon_rel_path: str = 'assets/icon.png'):
+    """
+    Start a Windows system tray icon with menu to open UI and exit.
+    Safe no-op on platforms without pystray or in headless environments.
+    """
+    global _icon, _icon_thread, _running
+    if _running:
+        return
+
+    try:
+        import pystray
+        from pystray import MenuItem as item, Menu
+    except Exception:
+        logging.warning("pystray not available; skipping tray icon")
+        return
+
+    icon_path = _resolve_asset_path(icon_rel_path)
+    image = _get_icon_image(icon_path)
+    if image is None:
+        logging.warning("tray icon image not found: %s", icon_path)
+
+    def on_open():
+        try:
+            webbrowser.open(url)
+        except Exception:
+            logging.exception("failed to open browser for %s", url)
+
+    def on_exit(icon, item_):
+        try:
+            stop_tray()
+        except Exception:
+            pass
+        # Hard exit process to stop background server
+        os._exit(0)
+
+    menu = Menu(
+        item("Open UI", lambda: on_open()),
+        item("Exit", lambda: on_exit(_icon, None))
+    )
+
+    _icon = pystray.Icon(app_name, image, app_name, menu)
+
+    def run_icon():
+        try:
+            _icon.run()
+        except Exception:
+            logging.exception("tray icon crashed")
+
+    _icon_thread = threading.Thread(target=run_icon, daemon=True)
+    _icon_thread.start()
+    _running = True
+
+
+def stop_tray():
+    global _icon, _icon_thread, _running
+    if not _running:
+        return
+    try:
+        if _icon is not None:
+            _icon.stop()
+    except Exception:
+        pass
+    _icon = None
+    _icon_thread = None
+    _running = False
+


### PR DESCRIPTION
Add fallback for `sys.stderr` and `sys.stdout` to prevent `AttributeError: 'NoneType' object has no attribute 'isatty'` in packaged web apps.

The error occurred because uvicorn's logging configuration attempts to call `isatty()` on `sys.stderr` or `sys.stdout`, which can be `None` when the application is run as a packaged GUI executable without a console. This change ensures these streams are directed to `os.devnull` if they are `None`, allowing uvicorn to initialize logging without crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cc93da4-f77c-4ece-8859-7c0c9d7752e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cc93da4-f77c-4ece-8859-7c0c9d7752e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

